### PR TITLE
Use regenerator to run tests in any version of Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.DS_Store
 node_modules
+test/*.es5.js

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
 	},
 	"main": "lib/suspend.js",
 	"scripts": {
-		"test": "./node_modules/mocha/bin/mocha --harmony-generators --reporter list"
+		"test": "node test/run.js"
 	},
 	"devDependencies": {
 		"mocha": "1.11.x",
-		"q": "0.9.x"
+		"q": "0.9.x",
+		"regenerator": "0.2.x",
+		"semver": "2.2.x"
 	},
 	"engines": {
-		"node": ">=0.11.2"
+		"node": ">=0.6"
 	},
 	"license": "MIT"
 }

--- a/test/run.js
+++ b/test/run.js
@@ -1,0 +1,88 @@
+var fs = require("fs");
+var semver = require("semver");
+var spawn = require("child_process").spawn;
+var regenerator = require("regenerator");
+
+function convert(es6File, es5File, callback) {
+	fs.readFile(es6File, "utf-8", function(err, es6) {
+		if (err) {
+			return callback(err);
+		}
+
+		fs.writeFile(es5File, regenerator(es6, {
+			includeRuntime: true
+		}), callback);
+	});
+}
+
+var queue = [];
+function enqueue(cmd, args) {
+	queue.push({
+		cmd: cmd,
+		args: args || []
+	});
+}
+
+function flush() {
+	var entry = queue.shift();
+	if (entry) {
+		var cmd = entry.cmd;
+		if (typeof cmd === "function") {
+			if (cmd.length > 1) {
+				// If the command accepts a parameter, let it call the
+				// asyncCallback itself.
+				cmd.apply(null, entry.args.concat(asyncCallback));
+			} else {
+				cmd.apply(null, entry.args);
+				asyncCallback();
+			}
+		} else {
+			spawn(cmd, entry.args, {
+				stdio: "inherit"
+			}).on("exit", asyncCallback);
+		}
+	}
+}
+
+function asyncCallback(err) {
+	if (err) {
+		console.error("process exited abnormally:", err);
+		process.exit(typeof err === "number" ? err : -1);
+	} else {
+		process.nextTick(flush);
+	}
+}
+
+enqueue(convert, [
+	"./test/promises.js",
+	"./test/promises.es5.js"
+]);
+
+enqueue(convert, [
+	"./test/resume.js",
+	"./test/resume.es5.js"
+]);
+
+enqueue(convert, [
+	"./test/snafus.js",
+	"./test/snafus.es5.js"
+]);
+
+if (semver.gte(process.version, "0.11.2")) {
+	enqueue("echo", ["Running tests with --harmony-generators..."]);
+	enqueue("mocha", [
+		"--harmony-generators",
+		"--reporter", "list",
+		"./test/promises.js",
+		"./test/resume.js",
+		"./test/snafus.js",
+	]);
+}
+
+enqueue("echo", ["Running tests with regenerator..."]);
+enqueue("mocha", [
+	"--reporter", "list",
+	"./test/*.es5.js",
+]);
+
+flush();


### PR DESCRIPTION
The https://github.com/facebook/regenerator project transforms ES6 generator functions into ES5 that behaves the same way, so Node.js v0.11.2 is no longer a strict requirement for using https://github.com/jmar777/suspend.

More explanation about regenerator can be found [here](http://facebook.github.io/regenerator/) and [here](https://news.ycombinator.com/item?id=6594207).

In Node.js v0.11.2 and above, the tests will still run natively using the `--harmony-generators` flag in addition to running in translation using regenerator.

To be clear, this pull request does not impose regenerator on users of suspend who only need compatibility with Node.js v0.11.2, but it does demonstrate that it's possible to use suspend in any ES5-compatible environment.
