### PR TITLE
make sync callbacks explicit

### DIFF
--- a/lib/suspend.js
+++ b/lib/suspend.js
@@ -11,8 +11,12 @@ function Suspend(generator, opts) {
 	// reusable, chainable bound reference of resume
 	this.resumer = function() {
 		var args = arguments;
+		self.resume.apply(self, args);
+	}
+	this.resumer.sync = function() {
+		var args = arguments;
 		setImmediate(function() {
-			self.resume.apply(self, args);
+			self.resumer.apply(self, args);
 		});
 	}
 	this.resumer.raw = function() {

--- a/test/snafus.js
+++ b/test/snafus.js
@@ -22,7 +22,7 @@ describe('suspend', function() {
 
 	it('should handle synchronous results', function(done) {
 		suspend(function*(resume) {
-			var doubled = yield syncDouble(42, resume);
+			var doubled = yield syncDouble(42, resume.sync);
 			assert.strictEqual(doubled, 84);
 			done();
 		})();
@@ -30,7 +30,7 @@ describe('suspend', function() {
 
 	it('should handle multiple runs', function(done) {
 		var test = suspend(function*(next, resume) {
-			var doubled = yield syncDouble(42, resume);
+			var doubled = yield syncDouble(42, resume.sync);
 			assert.strictEqual(doubled, 84);
 			next();
 		});


### PR DESCRIPTION
I'm submitting this PR in response to 1bda954d0da1c508918cdaab59234bef299262b6 
Suspend is now using 2 cycles to handle off async callbacks in favour of normalizing sync callbacks. 
I'm sure the performance impact of this is minimal but this doesn't feel like the right thing to do.

Adding a `sync` resumator option to the resume callback fixes this by allowing to signal that the callback is synchronous.
This also provides better code documentation, when reading through a `suspend` function a developer immediately notices if a callback is synchronous or asynchronous.

You could argue that sometimes you don't know if a callback is going to be async or sync, this is really more an inconsistency in the library you are using. But this can of course be fixed by just using the sync resumator which will handle both cases fine.

This PR will break synchronous promises, you can fix this like this:

```
yield doStuffEventually.then(r.sync);
```

I don't really know a better way to fix it at this moment. Any feedback is appreciated.
