### PR TITLE
sync detect

### DIFF
--- a/lib/suspend.js
+++ b/lib/suspend.js
@@ -7,13 +7,30 @@ function Suspend(generator, opts) {
 	this.opts = opts || {};
 	this.done = false;
 	this.rawOnce = false;
+	this.syncFlag = false;
+	this.syncArgs = null;
 
+	this.resetSyncFlag = function() {
+		self.syncFlag = false;
+		if (self.syncArgs) {
+			self.resumer.apply(self, self.syncArgs);
+		}
+	};
+	this.setSyncFlag = function() {
+		self.syncFlag = true;
+		self.syncArgs = null;
+		setImmediate(self.resetSyncFlag);
+	};
 	// reusable, chainable bound reference of resume
 	this.resumer = function() {
 		var args = arguments;
-		setImmediate(function() {
+		if (self.syncFlag) {
+			self.syncFlag = false;
+			self.syncArgs = args;
+		} else {
+			self.setSyncFlag();
 			self.resume.apply(self, args);
-		});
+		}
 	}
 	this.resumer.raw = function() {
 		self.rawOnce = true;
@@ -24,6 +41,7 @@ function Suspend(generator, opts) {
 Suspend.prototype.startGenerator = function startGenerator(ctx, args) {
 	args.push(this.resumer);
 	this.iterator = this.generator.apply(ctx, args);
+	this.setSyncFlag();
 	this.handleYield(this.iterator.next());
 };
 


### PR DESCRIPTION
continuation of #10

I understand the need for the transparent resolution. Although i do think that sync callbacks are an edge case and ~~that handling them explicitly seems appropriate, even more so because of the increased code documentation then the neglectable performance gain.~~ I'm actually starting to think that this approach might in fact be more elegant than  #10.

Anyway, i followed up on your advice and implemented some setImmediate magic in order to detect if the call is synchronous. 
If the callback is asynchronous then `resume` is called immediately, if it is synchronous the arguments are stored on the instance and  `resume` will be called from the `setImmediate` function call that was already started to check if the call is synchronous. 

I have no idea if this will cause anything to be faster than the current implementation but i do feel this might resolve async handlers more naturally.
