### PR TITLE
exclude folders from test files

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -6,7 +6,7 @@ var fs = require('fs'),
 
 // get our test files
 var testFiles = fs.readdirSync(__dirname).filter(function(fileName) {
-	return !/(?:^run|\.es5)\.js$/.test(fileName);
+	return fileName.slice(-3) === '.js' && !/(?:^run|\.es5)\.js$/.test(fileName);
 }).map(function(fileName) {
 	return './test/' + fileName;
 });


### PR DESCRIPTION
Continuation of #9
Tests broke on my machine because my IDE ( webstorm ) added a hidden folder to the test folder. 
Which then throws an error when using node `0.10.21` because `run.js` will attempt to regenerate this folder.

I'm not sure if this is a fix you want but it worked for me.
