### PR TITLE
Support for context data associated with parallel tasks, supplied to fork() operation

### DIFF
--- a/lib/suspend.js
+++ b/lib/suspend.js
@@ -117,12 +117,12 @@ suspend.resumeRaw = function resumeRawFactory() {
  * Used for "forking" parallel operations. Rather than resuming the generator,
  * completion values are stored until a subsequent `.join()` operation.
  */
-suspend.fork = function fork() {
+suspend.fork = function fork(data) {
 	var suspender = getActiveSuspender();
 	if (!suspender) {
 		throw new Error('fork() must be called from the generator body.');
 	}
-	return suspender.forkFactory();
+	return suspender.forkFactory(data);
 };
 
 /**
@@ -174,6 +174,8 @@ function Suspender(generator, callback) {
 	this.rawResume = false;
 	// holding place for values from forked operations, waiting for a join()
 	this.forkValues = [];
+	// holding place for additional data supplied to fork()
+	this.forkData = [];
 	// number of pending forks we have out there
 	this.pendingForks = 0;
 	// index used for preserving fork result positions
@@ -275,7 +277,7 @@ Suspender.prototype.resume = function resume(err, result) {
  * Returns a fork continuation that stashes the fulfillment value until `join()`
  * is subsequently called.
  */
-Suspender.prototype.forkFactory = function forkFactory() {
+Suspender.prototype.forkFactory = function forkFactory(data) {
 	var self = this,
 		index = this.forkIndex++,
 		alreadyFulfilled = false;
@@ -286,6 +288,9 @@ Suspender.prototype.forkFactory = function forkFactory() {
 		}
 		alreadyFulfilled = true;
 		self.forkValues[index] = Array.prototype.slice.call(arguments);
+		if (data) {
+			self.forkData[index] = data;
+		}
 		if (--self.pendingForks === 0 && self.pendingJoin) {
 			self.join();
 		}
@@ -303,11 +308,16 @@ Suspender.prototype.join = function join() {
 		results = [];
 	for (var i = 0, len = this.forkValues.length; i < len; i++) {
 		var forkValue = this.forkValues[i];
+		var forkData = this.forkData[i];
 		if (forkValue[0]) {
 			err = forkValue[0];
 			break;
 		} else {
-			results[i] = forkValue[1];
+			if (forkData) {
+				results[i] = {data: forkData, value: forkValue[1]};
+			} else {
+				results[i] = forkValue[1];
+			}
 		}
 	}
 	// reset fork/join state
@@ -315,6 +325,7 @@ Suspender.prototype.join = function join() {
 	this.pendingForks = 0;
 	this.forkIndex = 0;
 	this.forkValues.length = 0;
+	this.forkData.length = 0;
 
 	// resume the generator with our fork/join results
 	this.resume(err, results);

--- a/test/suspend.fork.js
+++ b/test/suspend.fork.js
@@ -14,11 +14,31 @@ describe('suspend.fork()', function() {
 		}, done);
 	});
 
+	it('should support data supplied to fork()', function(done) {
+		run(function*() {
+			asyncDouble(12, fork({name: 'k'}));
+			assert.deepEqual([{data: {name: 'k'}, value: 24}], yield join());
+		}, done);
+	});
+
 	it('should order results based on calls to fork()', function(done) {
 		run(function*() {
 			slowAsyncDouble(3, fork());
 			asyncDouble(4, fork());
 			assert.deepEqual([6, 8], yield join());
+		}, done);
+	});
+
+	it('should only wrap results with supplied data into onjects', function(done) {
+		run(function*() {
+			slowAsyncDouble(5, fork({name: 'c'}));
+			asyncDouble(6, fork());
+			asyncDouble(7, fork({name: 'd'}));
+			assert.deepEqual([
+				{data: {name: 'c'}, value: 10},
+				12,
+				{data: {name: 'd'}, value: 14}
+			], yield join());
 		}, done);
 	});
 


### PR DESCRIPTION
Hello! Thank you very much for your amazing project. 😊 
In our environment however we're using `suspend` to run a mix of different tasks (db queries, file reads) in parallel. For that sake it is helpful for us to associate some _data_ with the task so that later we can access the _context_ in which result was obtained.

Here's our proposal:

``` js
files.forEach(function(filepath) {
    fs.readFile(filepath, suspend.fork({filepath: filepath}));
});
var results = yield suspend.join();
// [ { data: { filepath: 'path/to/file/3' },
//    value: <Buffer ... > },
//  { data: { filepath: 'path/to/file/1' },
//    value: <Buffer ... > },
//  { data: { filepath: 'path/to/file/2' },
//    value: <Buffer ... > } ]
```

I hope this function has a chance to make it to the upstream. I would be very glad to hear your opinion about the matter. Maybe we could create a new method like `forkContext()` or `forkData()` to make the change as robust as possible in respect to backward compatibility.
Thank you and have a good day!
